### PR TITLE
fix: Add property for license text

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,8 @@ export interface PackageMeta {
 export interface LicenseMeta {
   name: string
   version: string
-  license: string | null
+  license: string
+  licenseText: string
 }
 
 interface TestMocks {


### PR DESCRIPTION
Hi Christoph,

My plan is to produce an output that resembles `license-webpack-plugin`. Since `licenseText` is already part of the `LicenseMeta` object, extending the type would be a quick win.

Johannes